### PR TITLE
Configure JWT plugin to use environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Couchbase configuration
+CRYPTO_MASTER_KEY=changeme
+CRYPTO_MASTER_KID=1
+COUCHBASE_HOST=couchbase
+COUCHBASE_ADMINISTRATOR_USERNAME=Administrator
+COUCHBASE_ADMINISTRATOR_PASSWORD=Password123!
+
+# RabbitMQ configuration
+RABBITMQ_HOST=rabbitmq
+RABBITMQ_USER=guest
+RABBITMQ_PASSWORD=guest
+RABBITMQ_PORT=5672
+
+# Authentication configuration
+# Provide a strong JWT secret (at least 16 characters with upper, lower, numeric and special chars).
+JWT_SECRET=ChangeMeNow!12345
+# Optional overrides
+JWT_EXPIRES_IN=1h
+JWT_COOKIE_MAX_AGE=3600
+JWT_COOKIE_NAME=token

--- a/src/plugins/auth.js
+++ b/src/plugins/auth.js
@@ -2,21 +2,73 @@ const fp = require('fastify-plugin');
 const fastifyCookie = require('@fastify/cookie');
 const fastifyJwt = require('@fastify/jwt');
 
-const authPlugin = async function(fastify, options){
+const MIN_SECRET_LENGTH = 16;
+
+function ensureStrongSecret(secret) {
+    if (typeof secret !== 'string' || secret.trim().length === 0) {
+        throw new Error('JWT_SECRET environment variable must be defined.');
+    }
+
+    if (secret.length < MIN_SECRET_LENGTH) {
+        throw new Error(`JWT_SECRET must be at least ${MIN_SECRET_LENGTH} characters long.`);
+    }
+
+    const hasUppercase = /[A-Z]/.test(secret);
+    const hasLowercase = /[a-z]/.test(secret);
+    const hasDigit = /\d/.test(secret);
+    const hasSymbol = /[^A-Za-z0-9]/.test(secret);
+
+    if (!hasUppercase || !hasLowercase || !hasDigit || !hasSymbol) {
+        throw new Error('JWT_SECRET must include uppercase, lowercase, numeric, and special characters.');
+    }
+}
+
+function parseCookieMaxAge(value) {
+    if (typeof value === 'undefined' || value === null || value === '') {
+        return 60 * 60;
+    }
+
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error('JWT_COOKIE_MAX_AGE must be a positive number representing seconds.');
+    }
+
+    return Math.floor(parsed);
+}
+
+const authPlugin = async function (fastify) {
+    const secret = process.env.JWT_SECRET;
+    const expiresIn = process.env.JWT_EXPIRES_IN || '1h';
+    const cookieName = process.env.JWT_COOKIE_NAME || 'token';
+    const cookieMaxAge = parseCookieMaxAge(process.env.JWT_COOKIE_MAX_AGE);
+
+    ensureStrongSecret(secret);
+
     fastify.register(fastifyCookie);
     fastify.register(fastifyJwt, {
-        secret: 'MySuperSecret1!',
-        cookie:{
-            cookieName: 'token',
-            signed: false
-        }
-    })
-    fastify.decorate('authenticate', async function(request, reply){
-        try{
+        secret,
+        sign: {
+            expiresIn,
+        },
+        cookie: {
+            cookieName,
+            signed: false,
+        },
+    });
+
+    fastify.decorate('jwtConfig', Object.freeze({
+        expiresIn,
+        cookieName,
+        cookieMaxAge,
+    }));
+
+    fastify.decorate('authenticate', async function (request, reply) {
+        try {
             await request.jwtVerify();
-        }catch(err){
-            reply.code(401).send({error: 'unauthorized'});
+        } catch (err) {
+            reply.code(401).send({ error: 'unauthorized' });
         }
-    })
-}
+    });
+};
+
 module.exports = fp(authPlugin);

--- a/src/routes/auth/login.js
+++ b/src/routes/auth/login.js
@@ -1,34 +1,36 @@
 const fp = require('fastify-plugin');
-const {loginUser} = require('../../services/authService');
-const loginSchema = require('../../schemas/auth/loginSchema')
+const { loginUser } = require('../../services/authService');
+const loginSchema = require('../../schemas/auth/loginSchema');
 
-const loginRoute = async function(fastify, options){
+const loginRoute = async function (fastify) {
     fastify.route({
         method: 'POST',
-        url: '/api/auth/login', 
+        url: '/api/auth/login',
         schema: loginSchema,
-        handler: async function(request, reply){
-            const {username, password} = request.body;
-            const user = await loginUser(fastify, {username, password});
-            const token = fastify.jwt.sign(
-                {sub: user.id, username: user.username},
-                {expiresIn: '1h'}
-            );
-            reply.setCookie('token', token, {
-                httpOnly: 'true',
+        handler: async function (request, reply) {
+            const { username, password } = request.body;
+            const user = await loginUser(fastify, { username, password });
+            const token = fastify.jwt.sign({
+                sub: user.id,
+                username: user.username,
+            });
+            const { cookieName, cookieMaxAge } = fastify.jwtConfig;
+            reply.setCookie(cookieName, token, {
+                httpOnly: true,
                 sameSite: 'Strict',
                 path: '/',
                 secure: process.env.NODE_ENV === 'production',
-                maxAge: 60*60
+                maxAge: cookieMaxAge,
             });
             reply.code(200).send({
-                message:'login successful',
-                user:{
+                message: 'login successful',
+                user: {
                     id: user.id,
-                    username: user.username
-                }
-            })
-        }
-    })
-}
+                    username: user.username,
+                },
+            });
+        },
+    });
+};
+
 module.exports = fp(loginRoute);

--- a/src/routes/auth/register.js
+++ b/src/routes/auth/register.js
@@ -1,34 +1,36 @@
 const fp = require('fastify-plugin');
-const {registerUser} = require('../../services/authService');
+const { registerUser } = require('../../services/authService');
 const registerSchema = require('../../schemas/auth/registerSchema');
 
-const registerRoute = async function(fastify, options){
+const registerRoute = async function (fastify) {
     fastify.route({
         method: 'POST',
-        url:'/api/auth/register',
+        url: '/api/auth/register',
         schema: registerSchema,
-        handler: async function(request, reply){
-            const {username, email, password} = request.body;
-            const user = await registerUser(fastify, {username, email, password});
-            const token = fastify.jwt.sign(
-                {sub:user.id, username:user.username},
-                {expiresIn: '1h'}
-            );
-            reply.setCookie('token', token, {
-                httpOnly: 'true',
+        handler: async function (request, reply) {
+            const { username, email, password } = request.body;
+            const user = await registerUser(fastify, { username, email, password });
+            const token = fastify.jwt.sign({
+                sub: user.id,
+                username: user.username,
+            });
+            const { cookieName, cookieMaxAge } = fastify.jwtConfig;
+            reply.setCookie(cookieName, token, {
+                httpOnly: true,
                 sameSite: 'Strict',
                 path: '/',
                 secure: process.env.NODE_ENV === 'production',
-                maxAge: 60*60
-            })
+                maxAge: cookieMaxAge,
+            });
             reply.code(201).send({
-                message:'user registered successfully',
-                user:{
+                message: 'user registered successfully',
+                user: {
                     id: user.id,
-                    username: user.username
-                }
-            })
-        }
-    })
-}
+                    username: user.username,
+                },
+            });
+        },
+    });
+};
+
 module.exports = fp(registerRoute);


### PR DESCRIPTION
## Summary
- load the Fastify JWT plugin configuration from environment variables with validation for the secret and cookie lifetime
- share the configured cookie name and lifetime with auth routes so token handling stays consistent
- document the JWT environment variables in a new `.env.example`

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d915f515648324be22269d0f9bd94a