### PR TITLE
Fix chat event error logging

### DIFF
--- a/src/sockets/chatEvents.js
+++ b/src/sockets/chatEvents.js
@@ -243,7 +243,7 @@ const registerChatEvents = function(fastify, io, socket, onlineUsersMap){
             })
             io.to(room).emit('recieveMessage', savedMessage, latestActionPlain);
         }catch(err){
-            fastify.error.log(err);
+            fastify.log.error(err);
             socket.emit('error', 'internal server error');
         }
     });
@@ -252,7 +252,7 @@ const registerChatEvents = function(fastify, io, socket, onlineUsersMap){
             const loadedMessages = await loadRoomMessage(fastify, roomId);
             socket.emit('displayMessages', loadedMessages, roomId);
         }catch(err){
-            fastify.error.log(err);
+            fastify.log.error(err);
             socket.emit('error', 'internal server error');
         }
     })


### PR DESCRIPTION
## Summary
- replace deprecated `fastify.error.log` usage with `fastify.log.error` in chat socket handlers

## Testing
- node - <<'NODE' ... (manual script to simulate `message` and `loadRoomMessages` handlers)


------
https://chatgpt.com/codex/tasks/task_b_68d9194112408324a5266daa0730acfb