### PR TITLE
Register Fastify sensible in worker and improve error handling

### DIFF
--- a/src/services/usersService.js
+++ b/src/services/usersService.js
@@ -1,5 +1,4 @@
 const couchbase = require('couchbase');
-const { default: fastify } = require('fastify');
 
 const _getUserDoc = async function(fastify, userId){
     return await fastify.couchbase.usersCollection.get(userId);
@@ -34,13 +33,13 @@ const addToGroups =async function(fastify, userId, groupId) {
     return user.groups;
   } catch (err) {
     if (err instanceof couchbase.DocumentNotFoundError) {
-      throw new Error('User not found');
+      throw fastify.httpErrors.notFound('user not found');
     }
     console.error(err);
-    throw new Error('Failed to update user groups');
+    throw fastify.httpErrors.internalServerError('failed to update user groups');
   }
 }
-const makeFriendRequest = async function(fastify, userId, friendUsername){  
+const makeFriendRequest = async function(fastify, userId, friendUsername){
   const friendId = `user::${friendUsername}`;
   try{
     await Promise.all([
@@ -53,9 +52,9 @@ const makeFriendRequest = async function(fastify, userId, friendUsername){
     ])
   }catch(err){
     if(err instanceof couchbase.DocumentNotFoundError){
-      return fastify.httpErrors.notFound('no user found');
+      throw fastify.httpErrors.notFound('no user found');
     }
-    throw new Error(err.message);
+    throw fastify.httpErrors.internalServerError(err.message);
   }
 }
 const addFriend = async function(fastify, userId, friendId) {

--- a/worker.js
+++ b/worker.js
@@ -17,6 +17,7 @@ const RABBIT_URL =`amqp://${process.env.RABBITMQ_USER}:${process.env.RABBITMQ_PA
 async function startWorker(){
     try{
         const fastify = Fastify();
+        fastify.register(require('@fastify/sensible'));
         fastify.register(couchbasePlugin);
         await fastify.ready();
         console.log('couchbase connected inside worker');
@@ -103,8 +104,12 @@ async function startWorker(){
                     }
                 }
             }catch(err){
-                console.log(err.message);
-                result = {success:false, error:err.message};
+                console.error(err);
+                result = {
+                    success:false,
+                    error: err?.message || 'unexpected error',
+                    ...(err?.statusCode ? {statusCode: err.statusCode} : {})
+                };
             }
             if(msg.properties.replyTo && msg.properties.correlationId){
                 channel.sendToQueue(


### PR DESCRIPTION
## Summary
- register `@fastify/sensible` on the worker Fastify instance before other shared services so `httpErrors` is always available
- propagate HTTP error metadata from worker task failures so callers receive status codes alongside error messages
- update user service helpers to throw Fastify HTTP errors when Couchbase lookups fail instead of returning generic errors

## Testing
- `node - <<'NODE' ...` (manual script verifying `makeFriendRequest` returns a not-found HTTP error)


------
https://chatgpt.com/codex/tasks/task_b_68d91fe4de9c8324a0f9078ff295c911